### PR TITLE
Pulling back in manual.html

### DIFF
--- a/play/manual/manual.html
+++ b/play/manual/manual.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+	<title>This is a Manual Simulation</title>
+	<link href="manual.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+	<canvas id="canvas" width="550" height="550"></canvas>
+	<br><br>
+	<div id="reset" onclick="reset()"></div>
+</body>
+</html>
+
+<script src="../lib/Mouse.js"></script>
+<script src="manual.js"></script>


### PR DESCRIPTION
The previous removal of manual.html appears to have been improper. It is still referenced in the index and is important to the site. Pulling back the latest version.